### PR TITLE
Fix VGM player freeze on macOS due to integer overflow

### DIFF
--- a/Player/Player.hpp
+++ b/Player/Player.hpp
@@ -236,6 +236,7 @@ public:
 
 	static timespec nsec_to_timespec(uint64_t nsec);
 	static void timespec_add(timespec &addee, timespec adder);
+	static int timespec_cmp(timespec a, timespec b);
 
 	int flush_and_sleep(uint32_t sleep_samples);
 };


### PR DESCRIPTION
The function `RetroWavePlayer::flush_and_sleep()` subtracts `time_now` from `sleep_end`, converts to nanoseconds and stores the result in a `uint64_t`. I've found that, on an Apple M1-based system, `time_now` is frequently greater than `sleep_end`, resulting in an integer overflow causing the player to freeze during playback.