### PR TITLE
Ensure that writes to GPIO extended writes both bank A and B (needed for OPL3 Express)

### DIFF
--- a/RetroWaveLib/Board/OPL3.c
+++ b/RetroWaveLib/Board/OPL3.c
@@ -82,7 +82,7 @@ void retrowave_opl3_emit_port1(RetroWaveContext *ctx, uint8_t reg, uint8_t val) 
 }
 
 void retrowave_opl3_reset(RetroWaveContext *ctx) {
-	uint8_t buf[] = {RetroWave_Board_OPL3, 0x12, 0xfe};
+	uint8_t buf[] = {RetroWave_Board_OPL3, 0x12, 0xfe, 0x00};
 	ctx->callback_io(ctx->user_data, transfer_speed / 10, buf, NULL, sizeof(buf));
 	buf[2] = 0xff;
 	ctx->callback_io(ctx->user_data, transfer_speed / 10, buf, NULL, sizeof(buf));

--- a/RetroWaveLib/RetroWave.c
+++ b/RetroWaveLib/RetroWave.c
@@ -61,7 +61,8 @@ void retrowave_io_init(RetroWaveContext *ctx) {
 	uint8_t init_sequence_1[] = {
 		0x00,
 		0x0a,	// IOCON register
-		0x28	// Enable: HAEN, SEQOP
+		0x28,	// Enable: HAEN, SEQOP
+		0x28
 	};
 
 	uint8_t init_sequence_2[] = {


### PR DESCRIPTION
As I am adding support for RetroWave OPL3 Express in adplay-unix I noticed that resetting the OPL3 IC didn't work.

If I added that we write to GPIOB aswell as GPIOA register, it started to work. I assume that the firmware that emulates MCP23S17 latches the MCU GPIO pins on every even data received, probably to ensure bus-timing.

Please review before applying